### PR TITLE
build(dev): make race detector opt-in via ND_DEV_RACE

### DIFF
--- a/reflex.conf
+++ b/reflex.conf
@@ -1,1 +1,2 @@
--s -r "(\.go$$|\.cpp$$|\.h$$|navidrome.toml|resources|token_received.html)" -R "(^ui|^data|^db/migrations)" -R "_test\.go$$" -- go run -race -tags netgo,sqlite_fts5 .
+# Set ND_DEV_RACE=1 (or true/yes/on) to build the backend with the race detector. Default: off (faster builds).
+-s -r "(\.go$$|\.cpp$$|\.h$$|navidrome.toml|resources|token_received.html)" -R "(^ui|^data|^db/migrations)" -R "_test\.go$$" -- sh -c 'case "${ND_DEV_RACE:-}" in 1|true|TRUE|yes|YES|on|ON) RACE=-race;; *) RACE=;; esac; exec go run $RACE -tags netgo,sqlite_fts5 .'


### PR DESCRIPTION
### Description
The `make dev` backend was always built with the race detector (`go run -race ...` in `reflex.conf`). `-race` adds significant compile time on every hot-reload, which is especially painful on low-powered dev machines (on a Raspberry Pi a `-race` build hadn't finished after 300s+, while a plain build was up in ~46s).

This makes `-race` **opt-in**: the reflex command is wrapped in `sh -c` so the flag is only appended when `ND_DEV_RACE` is set to a truthy value. The default (unset) builds without `-race` for faster iteration.

```
make dev                 # default: no race detector (fast)
ND_DEV_RACE=1 make dev   # with race detector
```

Accepted truthy values: `1 | true | TRUE | yes | YES | on | ON`. Anything else (unset, `false`, `0`) builds without `-race`.

### Related Issues
<!-- None -->

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): Developer build/tooling change to `reflex.conf` (no production code affected)

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

> No automated tests added: this only changes the dev hot-reload command in `reflex.conf` (a shell toggle), which isn't covered by the Go/JS test suites. Verified locally: `make format` (no changes), `make lint` (0 issues), `make test` (all packages pass).

### How to Test
1. Run `make dev` with no extra env. Expected: the backend compiles and starts **without** the race detector (faster build).
2. Run `ND_DEV_RACE=1 make dev`. Expected: the backend is built **with** `-race`.
3. Sanity-check the toggle resolves as expected:
   ```sh
   for v in "" 1 true false 0; do ND_DEV_RACE=$v sh -c \
     'case "${ND_DEV_RACE:-}" in 1|true|TRUE|yes|YES|on|ON) R=-race;; *) R=;; esac; echo "[$ND_DEV_RACE] go run $R ..."'; done
   ```
   Expected: `-race` only for `1` and `true`.

### Screenshots / Demos (if applicable)
<!-- N/A -->

### Additional Notes
- Behavior change for contributors: the dev backend no longer runs with `-race` by default. Anyone relying on the race detector during local dev should set `ND_DEV_RACE=1`.
- No impact on CI or production builds — this only touches the local `make dev` reflex command.
